### PR TITLE
[Feat(category)] 카테고리 생성/조회/수정/삭제 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,5 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml

--- a/.idea/ECC_PJ_BE.iml
+++ b/.idea/ECC_PJ_BE.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.38/57f8f5e02e92a30fd21b80cbd426a4172b5f8e29/lombok-1.18.38.jar" />
+        </processorPath>
+        <module name="BE.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="BE" options="-parameters" />
+      <module name="BE.main" options="-parameters" />
+      <module name="BE.test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" defaultCharsetForPropertiesFiles="UTF-8" />
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="PLATFORM" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$/BE/BE" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/BE/BE" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ECC_PJ_BE.iml" filepath="$PROJECT_DIR$/.idea/ECC_PJ_BE.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/BE/BE/build.gradle
+++ b/BE/BE/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'	//Swagger
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/BE/BE/src/main/java/com/linkrap/BE/BeApplication.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/BeApplication.java
@@ -2,7 +2,9 @@ package com.linkrap.BE;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BeApplication {
 

--- a/BE/BE/src/main/java/com/linkrap/BE/api/CategoryApiController.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/api/CategoryApiController.java
@@ -1,0 +1,48 @@
+package com.linkrap.BE.api;
+
+import com.linkrap.BE.dto.CategoryDto;
+import com.linkrap.BE.dto.ResponseFormat;
+import com.linkrap.BE.service.CategoryService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+public class CategoryApiController {
+    @Autowired
+    CategoryService categoryService;
+    //카테고리 생성
+    @PostMapping("/api/categories")
+    public ResponseFormat<CategoryDto> create(@RequestBody CategoryDto dto) {
+        int userId = 1; //임시 사용자
+        CategoryDto createdDto = categoryService.create(userId, dto);
+        return (createdDto!=null) ?
+                ResponseFormat.ok("카테고리 생성 완료", createdDto):
+                ResponseFormat.failure("요청 형식이 올바르지 않습니다.");
+    }
+    //카테고리 조회
+    @GetMapping("/api/categories")
+    public ResponseFormat<List<CategoryDto>> categories() {
+        List<CategoryDto> dtos = categoryService.categories();
+        return (dtos!=null) ?
+                ResponseFormat.ok("카테고리 조회 완료", dtos):
+                ResponseFormat.failure("요청 형식이 올바르지 않습니다.");
+    }
+    //카테고리 이름 수정
+    @PatchMapping("/api/categories/{categoryId}")
+    public ResponseFormat<CategoryDto> update(@PathVariable int categoryId, @RequestBody CategoryDto dto){
+        CategoryDto updatedDto = categoryService.update(categoryId, dto);
+        return (updatedDto!=null) ?
+                ResponseFormat.ok("카테고리 이름 수정 완료", updatedDto):
+                ResponseFormat.failure("요청 형식이 올바르지 않습니다.");
+    }
+    //카테고리 삭제
+    @DeleteMapping("/api/categories/{categoryId}")
+    public ResponseFormat<CategoryDto> delete(@PathVariable int categoryId){
+        CategoryDto deletedDto = categoryService.delete(categoryId);
+        return (deletedDto!=null) ?
+                ResponseFormat.ok("카테고리 삭제 완료", deletedDto):
+                ResponseFormat.failure("요청 형식이 올바르지 않습니다.");
+    }
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/dto/CategoryDto.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/dto/CategoryDto.java
@@ -1,0 +1,23 @@
+package com.linkrap.BE.dto;
+
+import com.linkrap.BE.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoryDto {
+    private int categoryId;
+    private String categoryName;
+
+    public static CategoryDto createCategoryDto(Category category) {
+        return new CategoryDto(
+                category.getCategoryId(),
+                category.getCategoryName()
+        );
+    }
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/dto/ResponseFormat.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/dto/ResponseFormat.java
@@ -1,0 +1,60 @@
+package com.linkrap.BE.dto;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ResponseFormat<T> {
+    private int code;
+    private HttpStatus status;
+    private String message;
+    private T data;
+
+    // Constructor without data
+    public ResponseFormat(HttpStatus status, String message) {
+        this(status, message, null);
+    }
+
+    // Constructor with data
+    public ResponseFormat(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    // Static factory method without data
+    public static <T> ResponseFormat<T> of(HttpStatus status, String message) {
+        return new ResponseFormat<>(status, message);
+    }
+
+    // Static factory method with data
+    public static <T> ResponseFormat<T> of(HttpStatus status, String message, T data) {
+        return new ResponseFormat<>(status, message, data);
+    }
+
+    // Convenience method for OK status with data
+    public static <T> ResponseFormat<T> ok(String message, T data) {
+        return ResponseFormat.of(HttpStatus.OK, message, data);
+    }
+
+    // Convenience method for creating a success response
+    public static <T> ResponseFormat<T> success(String message, T data) {
+        return ResponseFormat.of(HttpStatus.OK, message, data);
+    }
+
+    // Convenience method for creating a failure response
+    public static <T> ResponseFormat<T> failure(String message) {
+        return ResponseFormat.of(HttpStatus.BAD_REQUEST, message);
+    }
+
+    // Convenience method for creating an error response
+    public static <T> ResponseFormat<T> error(String message) {
+        return ResponseFormat.of(HttpStatus.INTERNAL_SERVER_ERROR, message);
+    }
+
+    // Convenience method for creating a response from an existing data object
+    public static <T> ResponseFormat<T> from(T data) {
+        return ResponseFormat.of(HttpStatus.OK, "Operation successful", data);
+    }
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/entity/Category.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/entity/Category.java
@@ -1,0 +1,46 @@
+package com.linkrap.BE.entity;
+
+import com.linkrap.BE.dto.CategoryDto;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.sql.Timestamp;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Builder
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int categoryId;
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private Users user;
+    @Column
+    private String categoryName;
+    @Column
+    @CreatedDate
+    private Timestamp createdAt;
+    @Column
+    @LastModifiedDate
+    private Timestamp updatedAt;
+
+    public static Category createCategory(Users user, CategoryDto dto) {
+        return Category.builder()
+                .user(user)
+                .categoryName(dto.getCategoryName())
+                .build();
+    }
+
+    public void patch(CategoryDto dto) {
+        if (dto.getCategoryName() != null)
+            this.categoryName = dto.getCategoryName();
+    }
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/entity/Users.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/entity/Users.java
@@ -1,0 +1,22 @@
+package com.linkrap.BE.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class Users {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userId;
+}
+

--- a/BE/BE/src/main/java/com/linkrap/BE/repository/CategoryRepository.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.linkrap.BE.repository;
+
+import com.linkrap.BE.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Integer> {
+
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/repository/UsersRepository.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/repository/UsersRepository.java
@@ -1,0 +1,7 @@
+package com.linkrap.BE.repository;
+
+import com.linkrap.BE.entity.Users;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UsersRepository extends CrudRepository<Users, Integer> {
+}

--- a/BE/BE/src/main/java/com/linkrap/BE/service/CategoryService.java
+++ b/BE/BE/src/main/java/com/linkrap/BE/service/CategoryService.java
@@ -1,0 +1,56 @@
+package com.linkrap.BE.service;
+
+import com.linkrap.BE.dto.CategoryDto;
+import com.linkrap.BE.entity.Category;
+import com.linkrap.BE.entity.Users;
+import com.linkrap.BE.repository.CategoryRepository;
+import com.linkrap.BE.repository.UsersRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CategoryService {
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    UsersRepository userRepository;
+
+    //카테고리 생성
+    public CategoryDto create(int userId, @RequestBody CategoryDto dto) {
+        //사용자 조회
+        Users loggedInUser = userRepository.findById(userId).orElseThrow(()->new IllegalArgumentException("등록되지 않은 사용자입니다."));
+        //카테고리 엔티티 생성
+        Category category = Category.createCategory(loggedInUser, dto);
+        //카테고리 엔티티를 DB에 저장
+        Category created = categoryRepository.save(category);
+        //DTO로 변환해 반환
+        return CategoryDto.createCategoryDto(created);
+    }
+
+    //카테고리 목록 조회
+    public List<CategoryDto> categories() {
+        return categoryRepository.findAll()
+                .stream()
+                .map(CategoryDto::createCategoryDto)
+                .collect(Collectors.toList());
+    }
+
+    //카테고리 수정
+    public CategoryDto update(int categoryId, CategoryDto dto) {
+        Category target = categoryRepository.findById(categoryId).orElseThrow(()->new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+        target.patch(dto);
+        Category updated = categoryRepository.save(target);
+        return CategoryDto.createCategoryDto(updated);
+    }
+
+    //카테고리 삭제
+    public CategoryDto delete(int categoryId) {
+        Category target = categoryRepository.findById(categoryId).orElseThrow(()->new IllegalArgumentException("존재하지 않는 카테고리입니다."));
+        categoryRepository.delete(target);
+        return CategoryDto.createCategoryDto(target);
+    }
+}

--- a/BE/BE/src/main/resources/application.properties
+++ b/BE/BE/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 spring.application.name=BE
+
+spring.h2.console.enabled=true
+
+spring.jpa.defer-datasource-initialization=true
+
+#DB URL 설정
+#유니크 URL 생성하지 않기
+spring.datasource.generate-unique-name=false
+#고정 URL 설정하기
+spring.datasource.url=jdbc:h2:mem:eccteam1db

--- a/BE/BE/src/main/resources/data.sql
+++ b/BE/BE/src/main/resources/data.sql
@@ -1,0 +1,8 @@
+INSERT INTO users() VALUES ();
+INSERT INTO users() VALUES ();
+
+INSERT INTO category(user_id, category_name, created_at, updated_at) VALUES (1, '고양이', CURRENT_TIMESTAMP(), NULL);
+INSERT INTO category(user_id, category_name, created_at, updated_at) VALUES (1, '맛집', CURRENT_TIMESTAMP(), NULL);
+INSERT INTO category(user_id, category_name, created_at, updated_at) VALUES (1, '게임', CURRENT_TIMESTAMP(), NULL);
+INSERT INTO category(user_id, category_name, created_at, updated_at) VALUES (2, '강아지', CURRENT_TIMESTAMP(), NULL);
+INSERT INTO category(user_id, category_name, created_at, updated_at) VALUES (2, '취미', CURRENT_TIMESTAMP(), NULL);


### PR DESCRIPTION
### PR 타입
-[✅] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
be/yeseul/category -> main

### 변경 사항
카테고리 생성/조회/수정/삭제 기능 구현했습니다.

### 테스트 결과
Swagger에서 동작 확인하였습니다.
- 카테고리 목록 조회
<img width="500" height="495" alt="image" src="https://github.com/user-attachments/assets/f9d02d7f-5e3b-45ad-ab0c-84df2a11bb4e" />
- 새 카테고리 추가
<img width="523" height="178" alt="image" src="https://github.com/user-attachments/assets/5723c858-b881-430a-834b-4d9f0618e3c3" />
- 6번 카테고리 이름 수정
<img width="485" height="172" alt="image" src="https://github.com/user-attachments/assets/949b8ea2-9bf2-45de-b607-24dab5f500eb" />
- 6번 카테고리 삭제
<img width="491" height="171" alt="image" src="https://github.com/user-attachments/assets/30d907bb-16a8-4891-b491-db5f2c290e94" />